### PR TITLE
Refactor tensor creation APIs, add some dtypes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,6 +1177,7 @@ dependencies = [
  "bindgen_cuda",
  "candle-core",
  "cudarc",
+ "half",
  "hf-hub",
  "safetensors 0.5.3",
  "tokenizers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ safetensors = "0.5.3"
 hf-hub = { version = "0.4.2", default-features = false, features = ["ureq", "tokio", "rustls-tls"] }
 tokenizers = { version = "0.21.1", features = ["hf-hub"] }
 candle-core = "0.8.4"
+half = "2.6.0"
 
 [build-dependencies]
 anyhow = "1.0.97"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,4 @@ pub mod tensor;
 
 pub use linear::Linear;
 pub use model::Module;
-pub use tensor::Tensor;
+pub use tensor::{DTypeLike, Tensor};

--- a/src/linear.rs
+++ b/src/linear.rs
@@ -1,6 +1,6 @@
 // linear.rs
 use crate::tensor::Tensor;
-use candle_core::{D, Shape};
+use candle_core::{D, Layout, Shape};
 use cudarc::cublaslt::{CudaBlasLT, Matmul, MatmulConfig, MatmulShared};
 
 pub struct Linear {
@@ -108,7 +108,7 @@ impl Linear {
             )?;
         }
 
-        let res = Tensor::new_contiguous(out, out_shape, 0);
+        let res = Tensor::from_raw(out, Layout::contiguous(out_shape))?;
         res.transpose(D::Minus1, D::Minus2)
     }
 }

--- a/src/linear.rs
+++ b/src/linear.rs
@@ -60,7 +60,7 @@ where
                 if bias_l.shape().dims1()? != m {
                     anyhow::bail!("Bias does not have the correct shape");
                 }
-                (Some(bias.view().slice(bias_l.start_offset()..)), None)
+                (Some(bias.view()), None)
             } else {
                 if bias_l.shape().dims2()?.1 != m {
                     anyhow::bail!("Bias does not have the correct shape");
@@ -69,10 +69,7 @@ where
                     anyhow::bail!("Bias batch size must match batch size of `a`");
                 }
                 let bias_stride = bias_l.stride()[0] as i64;
-                (
-                    Some(bias.view().slice(bias_l.start_offset()..)),
-                    Some(bias_stride),
-                )
+                (Some(bias.view()), Some(bias_stride))
             }
         } else {
             (None, None)

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,19 +25,9 @@ fn main() -> anyhow::Result<()> {
     ];
 
     // Create tensors with explicit column-major strides
-    let input = Tensor::from_host(
-        stream.clone(),
-        &x_host,
-        vec![batch_size, in_features],
-        vec![1, batch_size], // Column-major strides
-    )?;
+    let input = Tensor::from_vec(stream.clone(), &x_host, vec![batch_size, in_features])?;
 
-    let weight = Tensor::from_host(
-        stream.clone(),
-        &w_host,
-        vec![in_features, out_features],
-        vec![1, in_features], // Column-major strides
-    )?;
+    let weight = Tensor::from_vec(stream.clone(), &w_host, vec![in_features, out_features])?;
 
     let linear = Linear::new(weight, None);
     let output = linear.forward(&input)?;

--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -6,6 +6,7 @@ use cudarc::{
     },
     nvrtc::Ptx,
 };
+use half::{bf16, f16};
 use std::sync::Arc;
 
 use crate::modules;
@@ -14,9 +15,24 @@ pub trait DTypeLike: DeviceRepr + ValidAsZeroBits + Clone + Copy {
     const DTYPE: &'static str;
 }
 
-impl DTypeLike for f32 {
-    const DTYPE: &'static str = "f32";
+macro_rules! instantiate_dtypelike {
+    ($t:ty) => {
+        impl DTypeLike for $t {
+            const DTYPE: &'static str = stringify!($t);
+        }
+    };
 }
+instantiate_dtypelike!(f32);
+instantiate_dtypelike!(f16);
+instantiate_dtypelike!(bf16);
+instantiate_dtypelike!(u8);
+instantiate_dtypelike!(u16);
+instantiate_dtypelike!(u32);
+instantiate_dtypelike!(u64);
+instantiate_dtypelike!(i8);
+instantiate_dtypelike!(i16);
+instantiate_dtypelike!(i32);
+instantiate_dtypelike!(i64);
 
 #[derive(Debug, Clone)]
 pub struct Tensor<T: DTypeLike> {

--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -74,10 +74,12 @@ impl<T: DTypeLike> Tensor<T> {
         Self::from_raw(dst, layout)
     }
 
+    /// This returns a pre-sliced view of the tensor data.
     pub fn view(&self) -> CudaView<T> {
         self.data.as_view().slice(self.layout.start_offset()..)
     }
 
+    /// This returns a pre-sliced view of the tensor data.
     pub fn view_mut(&mut self) -> CudaViewMut<T> {
         self.data
             .as_view_mut()

--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -26,43 +26,58 @@ pub struct Tensor<T: DTypeLike> {
 }
 
 impl<T: DTypeLike> Tensor<T> {
-    pub fn new_strided<S: Into<Shape>>(
-        data: CudaSlice<T>,
-        shape: S,
-        stride: Vec<usize>,
-        start_offset: usize,
-    ) -> Self {
-        let shape = shape.into();
-        Self {
+    pub fn from_raw(data: CudaSlice<T>, layout: Layout) -> anyhow::Result<Self> {
+        if data.len() != layout.shape().elem_count() {
+            anyhow::bail!(
+                "from_raw expects slice len {} to match layout elem count {}",
+                data.len(),
+                layout.shape().elem_count()
+            );
+        }
+        Ok(Self {
             stream: data.stream().clone(),
             data,
-            layout: Layout::new(shape, stride, start_offset),
-        }
+            layout,
+        })
     }
 
-    pub fn new_contiguous<S: Into<Shape>>(
-        data: CudaSlice<T>,
+    pub fn from_vec<S: Into<Shape>>(
+        stream: Arc<CudaStream>,
+        data: &[T],
         shape: S,
-        start_offset: usize,
-    ) -> Self {
-        let shape = shape.into();
-        Self {
-            stream: data.stream().clone(),
-            data,
-            layout: Layout::contiguous_with_offset(shape.clone(), start_offset),
+    ) -> anyhow::Result<Self> {
+        let layout = Layout::contiguous(shape);
+        if data.len() != layout.shape().elem_count() {
+            anyhow::bail!(
+                "from_vec expects host data len {} to match layout elem count {}",
+                data.len(),
+                layout.shape().elem_count()
+            );
         }
+        let dst = stream.memcpy_stod(data)?;
+        Self::from_raw(dst, layout)
     }
 
     pub fn view(&self) -> CudaView<T> {
-        self.data.as_view()
+        self.data.as_view().slice(self.layout.start_offset()..)
     }
 
     pub fn view_mut(&mut self) -> CudaViewMut<T> {
-        self.data.as_view_mut()
+        self.data
+            .as_view_mut()
+            .slice_mut(self.layout.start_offset()..)
     }
 
     pub fn into_slice(self) -> CudaSlice<T> {
         self.data
+    }
+
+    pub fn dims(&self) -> &[usize] {
+        self.shape().dims()
+    }
+
+    pub fn stride(&self) -> &[usize] {
+        self.layout.stride()
     }
 
     pub fn shape(&self) -> &Shape {
@@ -116,7 +131,7 @@ impl<T: DTypeLike> Tensor<T> {
             builder.arg(&mut out);
             unsafe { builder.launch(LaunchConfig::for_num_elems(elem_count as u32))? };
 
-            Ok(Self::new_contiguous(out, self.shape().clone(), 0))
+            Self::from_raw(out, Layout::contiguous(self.shape()))
         }
     }
 
@@ -132,27 +147,5 @@ impl<T: DTypeLike> Tensor<T> {
             anyhow::bail!("All tensors must be on the same device ordinal.")
         }
         Ok(())
-    }
-}
-
-impl<T: DTypeLike> Tensor<T> {
-    pub fn from_host<S: Into<Shape>>(
-        stream: Arc<CudaStream>,
-        data: &[T],
-        shape: S,
-        stride: Vec<usize>,
-    ) -> anyhow::Result<Self> {
-        let dst = stream.memcpy_stod(data)?;
-        Ok(Self::new_strided(dst, shape, stride, 0))
-    }
-
-    pub fn from_zeros<S: Into<Shape>>(
-        stream: Arc<CudaStream>,
-        len: usize,
-        shape: S,
-        stride: Vec<usize>,
-    ) -> anyhow::Result<Self> {
-        let dst = stream.alloc_zeros::<T>(len)?;
-        Ok(Self::new_strided(dst, shape, stride, 0))
     }
 }

--- a/tests/linear.rs
+++ b/tests/linear.rs
@@ -15,11 +15,9 @@ fn test_linear_forward() {
     let w_host = (0..b * n * k).map(|x| x as f32).collect::<Vec<_>>();
     let b_host = (0..b * m).map(|x| x as f32).collect::<Vec<_>>();
 
-    let input =
-        Tensor::from_host(stream.clone(), &x_host, vec![b, m, k], vec![m * k, k, 1]).unwrap();
-    let weight =
-        Tensor::from_host(stream.clone(), &w_host, vec![b, n, k], vec![n * k, k, 1]).unwrap();
-    let bias = Tensor::from_host(stream.clone(), &b_host, vec![b, m], vec![m, 1]).unwrap();
+    let input = Tensor::from_vec(stream.clone(), &x_host, vec![b, m, k]).unwrap();
+    let weight = Tensor::from_vec(stream.clone(), &w_host, vec![b, n, k]).unwrap();
+    let bias = Tensor::from_vec(stream.clone(), &b_host, vec![b, m]).unwrap();
 
     let linear = Linear::new(weight, Some(bias));
     let output = linear.forward(&input).unwrap();


### PR DESCRIPTION
- Add f32/f16/bf16 and all integer dtypes
- Generics are leveraged to support more dtypes in cublaslt
- Pre-slice in .view